### PR TITLE
fix: dependency check uses wrong MFT binary names

### DIFF
--- a/ibswinfo.sh
+++ b/ibswinfo.sh
@@ -449,8 +449,7 @@ tools[sed]=""
 tools[tr]="coreutils"
 tools[paste]="coreutils"
 tools[mst]="MFT ($MFT_URL)"
-tools[mlxreg]="MFT ($MFT_URL)"
-tools[smpquery]="infiniband-diags"
+tools[mlxreg_ext]="MFT ($MFT_URL)"
 for t in "${!tools[@]}"; do
     type "$t" &>/dev/null || \
         err "$t not found${tools[$t]:+, please install ${tools[$t]}}"

--- a/tests/bin/mlxreg
+++ b/tests/bin/mlxreg
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-echo "mlxreg mock"

--- a/tests/bin/smpquery
+++ b/tests/bin/smpquery
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-echo "smpquery mock"


### PR DESCRIPTION
## Summary

Closes #2.

The startup dependency check verified two binaries that the script does not actually use:

1. **`mlxreg`** — the script calls `mlxreg_ext` everywhere. Recent MFT releases (4.30+) ship only `mlxreg_ext`. On such systems the script aborted with `error: mlxreg not found, please install MFT (...)` even though everything was in place.
2. **`smpquery`** — was a fallback to query the Subnet Manager for port count, removed by upstream commit `2934ea8` in favor of reading the `MGIR` register directly. The dependency entry was never cleaned up.

## Changes

| File | Change |
|------|--------|
| `ibswinfo.sh` | Replace `tools[mlxreg]` with `tools[mlxreg_ext]`, drop `tools[smpquery]` |
| `tests/bin/mlxreg` | Removed (dead mock) |
| `tests/bin/smpquery` | Removed (dead mock) |

## Test plan

- [x] `./tests/run_tests.sh` passes 6/6 dumps after removing the mocks. This is the actual proof: with `tests/bin/` first in `PATH`, removing the mocks means those binaries are no longer reachable. If the script still required them, it would error out at startup. It does not.
- [x] No reference to `mlxreg` (legacy) or `smpquery` remains in the codebase (`grep -rn` returns empty).

## Why no functional test added

The natural test for "the script no longer requires mlxreg/smpquery" is exactly what removing the mocks does — it makes those binaries unreachable from the test environment, and the test suite then verifies the script still works. Adding an explicit assertion would be redundant.