### PR TITLE
fix: JSON output is invalid when fields contain special characters

### DIFF
--- a/ibswinfo.sh
+++ b/ibswinfo.sh
@@ -148,6 +148,23 @@ sec_to_dhms() {
                                   $((s%60))
 }
 
+# escape a string for safe inclusion as a JSON string value.
+# Handles backslash, double-quote, and standard control characters
+# (\b \f \n \r \t). Other control bytes (0x00-0x1F) are passed through;
+# switch fields are not expected to contain them.
+# Order matters: backslash must be escaped first.
+json_escape() {
+    local s=$1
+    s=${s//\\/\\\\}
+    s=${s//\"/\\\"}
+    s=${s//$'\b'/\\b}
+    s=${s//$'\f'/\\f}
+    s=${s//$'\n'/\\n}
+    s=${s//$'\r'/\\r}
+    s=${s//$'\t'/\\t}
+    printf '%s' "$s"
+}
+
 # get register values
 #  $1: reg name
 #  $2: indexes (optional)
@@ -782,11 +799,38 @@ case $out in
         ;;
 
     json)
-        # Construct JSON output
-        echo -n "{\"node_description\":\"$nd\",\"inventory\":{\"part_number\":\"$pn\",\"serial\":\"$sn\",\"product_name\":\"$cn\",\"revision\":\"$rv\",\"psid\":\"$psid\",\"guid\":\"$guid\",\"fw_version\":\"$(printf "%d.%04d.%04d" "$maj" "$min" "$sub")\",\"cpld\":$cpld,\"psus\":["
-        first=1; for i in $psu_idxs; do [[ $first -eq 0 ]] && echo -n ","; echo -n "{\"id\":$i,\"part_number\":\"${ps[$i.pn]}\",\"serial\":\"${ps[$i.sn]}\"}"; first=0; done
-        echo -n "]},\"status\":{\"fans\":\"$fa\",\"psus\":["
-        first=1; for i in $psu_idxs; do [[ $first -eq 0 ]] && echo -n ","; echo -n "{\"id\":$i,\"status\":\"${ps[$i.pr]}\",\"dc\":\"${ps[$i.dc]}\",\"fan\":\"${ps[$i.fs]}\"}"; first=0; done
+        # Construct JSON output. All string values flow through json_escape()
+        # to neutralize backslashes, double quotes, and control characters
+        # that would otherwise break downstream JSON parsers (jq, Prometheus
+        # exporters, ...). Numeric values are emitted as-is.
+        fw_str=$(printf "%d.%04d.%04d" "$maj" "$min" "$sub")
+        echo -n "{\"node_description\":\"$(json_escape "$nd")\""
+        echo -n ",\"inventory\":{\"part_number\":\"$(json_escape "$pn")\""
+        echo -n ",\"serial\":\"$(json_escape "$sn")\""
+        echo -n ",\"product_name\":\"$(json_escape "$cn")\""
+        echo -n ",\"revision\":\"$(json_escape "$rv")\""
+        echo -n ",\"psid\":\"$(json_escape "$psid")\""
+        echo -n ",\"guid\":\"$(json_escape "$guid")\""
+        echo -n ",\"fw_version\":\"$(json_escape "$fw_str")\""
+        echo -n ",\"cpld\":$cpld,\"psus\":["
+        first=1
+        for i in $psu_idxs; do
+            [[ $first -eq 0 ]] && echo -n ","
+            echo -n "{\"id\":$i"
+            echo -n ",\"part_number\":\"$(json_escape "${ps[$i.pn]}")\""
+            echo -n ",\"serial\":\"$(json_escape "${ps[$i.sn]}")\"}"
+            first=0
+        done
+        echo -n "]},\"status\":{\"fans\":\"$(json_escape "$fa")\",\"psus\":["
+        first=1
+        for i in $psu_idxs; do
+            [[ $first -eq 0 ]] && echo -n ","
+            echo -n "{\"id\":$i"
+            echo -n ",\"status\":\"$(json_escape "${ps[$i.pr]}")\""
+            echo -n ",\"dc\":\"$(json_escape "${ps[$i.dc]}")\""
+            echo -n ",\"fan\":\"$(json_escape "${ps[$i.fs]}")\"}"
+            first=0
+        done
         echo -n "]},\"vitals\":{\"uptime_sec\":$s_uptime,\"temp_c\":$tp,\"max_temp_c\":$mt,\"temp_thresholds\":{\"low\":$twl,\"high\":$twh},\"fans_rpm\":{"
         first=1; for t in ${at_idxs:-}; do [[ $first -eq 0 ]] && echo -n ","; echo -n "\"fan_$t\":${fs[$t]}"; first=0; done
         echo -n "},\"psu_power_w\":{"

--- a/tests/dumps/ibsw_dump_LID77_JSON-SPECIAL.txt
+++ b/tests/dumps/ibsw_dump_LID77_JSON-SPECIAL.txt
@@ -1,0 +1,357 @@
+# TEST_METADATA
+# EXPECTED_PN=11891122
+# EXPECTED_LID=77
+# DATE=Mon Apr 27 12:30:47 PM CEST 2026
+# DEVICE=lid-77
+# NOTES=Synthetic fixture derived from the LID6 Sequana3 dump, with
+#       node_description rewritten to contain a double-quote (0x22),
+#       a backslash (0x5c), and a second double-quote — i.e. the string
+#       "a\b"c — so the JSON output path is exercised against characters
+#       that break naive string interpolation. Verifies json_escape()
+#       (Issue #3).
+======================================================================
+COMMAND: mst version
+======================================================================
+mst, mft 4.32.0-18, built on Jan 30 2025, 11:45:11. Git SHA Hash: N/A
+
+
+======================================================================
+COMMAND: mlxreg_ext -d lid-77 --reg_name MGIR --get
+======================================================================
+Sending access register...
+
+Field Name                      | Data
+=============================================
+device_id                       | 0x00001e01
+device_hw_revision              | 0x000000a0
+pvs                             | 0x00000000
+technology                      | 0x00000004
+num_ports                       | 0x00000080
+ib_mad_gen                      | 0x00000000
+hw_dev_id                       | 0x00000257
+module_master_fw_default        | 0x00000000
+ga_valid                        | 0x00000000
+development                     | 0x00000000
+manufacturing_base_mac_47_32    | 0x00000800
+ga                              | 0x00000000
+chip_type                       | 0x00000000
+manufacturing_base_mac_31_0     | 0x38c5bf00
+device_ticks_per_msec           | 0x00000000
+uptime                          | 0x0007a567
+sub_minor                       | 0x00000000
+minor                           | 0x00000000
+major                           | 0x00000000
+secured                         | 0x00000001
+signed_fw                       | 0x00000001
+debug                           | 0x00000000
+dev                             | 0x00000000
+string_tlv                      | 0x00000001
+dev_sc                          | 0x00000000
+build_id                        | 0x00000000
+year                            | 0x00002025
+day                             | 0x00000010
+month                           | 0x00000007
+hour                            | 0x00002050
+psid[3]                         | 0x00000031
+psid[2]                         | 0x0000005f
+psid[1]                         | 0x0000004c
+psid[0]                         | 0x00000042
+psid[7]                         | 0x00000032
+psid[6]                         | 0x00000030
+psid[5]                         | 0x00000030
+psid[4]                         | 0x00000032
+psid[11]                        | 0x00000000
+psid[10]                        | 0x00000031
+psid[9]                         | 0x00000030
+psid[8]                         | 0x00000031
+psid[15]                        | 0x00000000
+psid[14]                        | 0x00000000
+psid[13]                        | 0x00000000
+psid[12]                        | 0x00000000
+ini_file_version                | 0x00000000
+extended_major                  | 0x0000001f
+extended_minor                  | 0x000007e0
+extended_sub_minor              | 0x00000404
+isfu_major                      | 0x00000001
+disabled_tiles_bitmap           | 0x0000ff00
+life_cycle                      | 0x00000001
+sec_boot                        | 0x00000001
+encryption                      | 0x00000001
+life_cycle_msb                  | 0x00000000
+issu_able                       | 0x00000000
+pds                             | 0x00000000
+sub_minor                       | 0x00000000
+minor                           | 0x00000000
+major                           | 0x00000000
+rom3_type                       | 0x00000000
+rom3_arch                       | 0x00000000
+rom2_type                       | 0x00000000
+rom2_arch                       | 0x00000000
+rom1_type                       | 0x00000000
+rom1_arch                       | 0x00000000
+rom0_type                       | 0x00000000
+rom0_arch                       | 0x00000000
+build                           | 0x00000000
+minor                           | 0x00000000
+major                           | 0x00000000
+build                           | 0x00000000
+minor                           | 0x00000000
+major                           | 0x00000000
+build                           | 0x00000000
+minor                           | 0x00000000
+major                           | 0x00000000
+build                           | 0x00000000
+minor                           | 0x00000000
+major                           | 0x00000000
+dev_branch_tag[3]               | 0x00000000
+dev_branch_tag[2]               | 0x00000000
+dev_branch_tag[1]               | 0x00000000
+dev_branch_tag[0]               | 0x00000000
+dev_branch_tag[7]               | 0x00000000
+dev_branch_tag[6]               | 0x00000000
+dev_branch_tag[5]               | 0x00000000
+dev_branch_tag[4]               | 0x00000000
+dev_branch_tag[11]              | 0x00000000
+dev_branch_tag[10]              | 0x00000000
+dev_branch_tag[9]               | 0x00000000
+dev_branch_tag[8]               | 0x00000000
+dev_branch_tag[15]              | 0x00000000
+dev_branch_tag[14]              | 0x00000000
+dev_branch_tag[13]              | 0x00000000
+dev_branch_tag[12]              | 0x00000000
+dev_branch_tag[19]              | 0x00000000
+dev_branch_tag[18]              | 0x00000000
+dev_branch_tag[17]              | 0x00000000
+dev_branch_tag[16]              | 0x00000000
+dev_branch_tag[23]              | 0x00000000
+dev_branch_tag[22]              | 0x00000000
+dev_branch_tag[21]              | 0x00000000
+dev_branch_tag[20]              | 0x00000000
+dev_branch_tag[27]              | 0x00000000
+dev_branch_tag[26]              | 0x00000000
+dev_branch_tag[25]              | 0x00000000
+dev_branch_tag[24]              | 0x00000000
+=============================================
+
+
+======================================================================
+COMMAND: mlxreg_ext -d lid-77 --reg_name MGPIR --get --indexes slot_index=0x0
+======================================================================
+Sending access register...
+
+Field Name                   | Data
+==========================================
+num_of_devices               | 0x00000000
+num_of_modules_per_system    | 0x00000020
+devices_per_flash            | 0x00000000
+device_type                  | 0x00000000
+slot_index                   | 0x00000000
+num_of_modules               | 0x00000020
+num_of_slots                 | 0x00000000
+max_modules_per_slot         | 0x00000020
+num_of_resource_modules      | 0x00000000
+max_sub_modules              | 0x00000000
+==========================================
+
+
+======================================================================
+COMMAND: mlxreg_ext -d lid-77 --reg_name MSGI --get
+======================================================================
+Sending access register...
+
+Field Name          | Data
+=================================
+serial_number[0]    | 0x4a303235
+serial_number[1]    | 0x31363031
+serial_number[2]    | 0x4a000000
+serial_number[3]    | 0x00000000
+serial_number[4]    | 0x00000000
+serial_number[5]    | 0x00000000
+part_number[0]      | 0x31313839
+part_number[1]      | 0x31313232
+part_number[2]      | 0x00000000
+part_number[3]      | 0x00000000
+part_number[4]      | 0x00000000
+revision            | 0x30303800
+product_name[0]     | 0x53657175
+product_name[1]     | 0x616e6133
+product_name[2]     | 0x20556e6d
+product_name[3]     | 0x6e672049
+product_name[4]     | 0x42203430
+product_name[5]     | 0x30000000
+product_name[6]     | 0x00000000
+product_name[7]     | 0x00000000
+product_name[8]     | 0x00000000
+product_name[9]     | 0x00000000
+product_name[10]    | 0x00000000
+product_name[11]    | 0x00000000
+product_name[12]    | 0x00000000
+product_name[13]    | 0x00000000
+product_name[14]    | 0x00000000
+product_name[15]    | 0x00000000
+=================================
+
+
+======================================================================
+COMMAND: mlxreg_ext -d lid-77 --reg_name MSCI --get --indexes index=0x0
+======================================================================
+Sending access register...
+
+Field Name      | Data
+=============================
+index           | 0x00000000
+version_type    | 0x00000000
+version         | 0x00000001
+=============================
+
+
+======================================================================
+COMMAND: mlxreg_ext -d lid-77 --reg_name SPZR --get --indexes swid=0x0
+======================================================================
+Sending access register...
+
+Field Name              | Data
+=====================================
+enh_sw_p0               | 0x00000000
+g0                      | 0x00000000
+ng                      | 0x00000000
+sig                     | 0x00000000
+mp                      | 0x00000000
+vk                      | 0x00000000
+cm                      | 0x00000000
+enh_sw_p0_mask          | 0x00000000
+ndm                     | 0x00000000
+cm2                     | 0x00000000
+router_entity           | 0x00000000
+swid                    | 0x00000000
+capability_mask         | 0xe550d848
+system_image_guid_h     | 0x08003803
+system_image_guid_l     | 0x00c5bf00
+guid0_h                 | 0x08003803
+guid0_l                 | 0x00c5bf00
+node_guid_h             | 0x08003803
+node_guid_l             | 0x00c5bf00
+capability_mask2        | 0x0000043b
+max_pkey                | 0x00000008
+node_description[0]     | 0x22615c62
+node_description[1]     | 0x22630000
+node_description[2]     | 0x00000000
+node_description[3]     | 0x00000000
+node_description[4]     | 0x00000000
+node_description[5]     | 0x00000000
+node_description[6]     | 0x00000000
+node_description[7]     | 0x00000000
+node_description[8]     | 0x00000000
+node_description[9]     | 0x00000000
+node_description[10]    | 0x00000000
+node_description[11]    | 0x00000000
+node_description[12]    | 0x00000000
+node_description[13]    | 0x00000000
+node_description[14]    | 0x00000000
+node_description[15]    | 0x00000000
+=====================================
+
+
+======================================================================
+COMMAND: mlxreg_ext -d lid-77 --reg_name MSPS --get
+======================================================================
+Sending access register...
+
+Field Name  | Data
+=========================
+psu0[0]     | 0x00000000
+psu0[1]     | 0x00000000
+psu0[2]     | 0x00000000
+psu0[3]     | 0x00000000
+psu0[4]     | 0x00000000
+psu0[5]     | 0x00000000
+psu0[6]     | 0x00000000
+psu0[7]     | 0x00000000
+psu0[8]     | 0x00000000
+psu0[9]     | 0x00000000
+psu0[10]    | 0x00000000
+psu0[11]    | 0x00000000
+psu0[12]    | 0x00000000
+psu0[13]    | 0x00000000
+psu0[14]    | 0x00000000
+psu0[15]    | 0x00000000
+psu0[16]    | 0x00000000
+psu0[17]    | 0x00000000
+psu0[18]    | 0x00000000
+psu0[19]    | 0x00000000
+psu1[0]     | 0x00000000
+psu1[1]     | 0x00000000
+psu1[2]     | 0x00000000
+psu1[3]     | 0x00000000
+psu1[4]     | 0x00000000
+psu1[5]     | 0x00000000
+psu1[6]     | 0x00000000
+psu1[7]     | 0x00000000
+psu1[8]     | 0x00000000
+psu1[9]     | 0x00000000
+psu1[10]    | 0x00000000
+psu1[11]    | 0x00000000
+psu1[12]    | 0x00000000
+psu1[13]    | 0x00000000
+psu1[14]    | 0x00000000
+psu1[15]    | 0x00000000
+psu1[16]    | 0x00000000
+psu1[17]    | 0x00000000
+psu1[18]    | 0x00000000
+psu1[19]    | 0x00000000
+=========================
+
+
+======================================================================
+COMMAND: mlxreg_ext -d lid-77 --reg_name MTMP --get --indexes sensor_index=0x0,slot_index=0x0
+======================================================================
+Sending access register...
+
+Field Name                  | Data
+=========================================
+sensor_index                | 0x00000000
+slot_index                  | 0x00000000
+asic_index                  | 0x00000000
+ig                          | 0x00000000
+i                           | 0x00000000
+temperature                 | 0x00000210
+max_temperature             | 0x00000328
+sdme                        | 0x00000000
+weme                        | 0x00000000
+mtr                         | 0x00000000
+mte                         | 0x00000000
+temperature_threshold_hi    | 0x00000348
+sdee                        | 0x00000000
+tee                         | 0x00000000
+temperature_threshold_lo    | 0x000002f8
+sensor_name_hi              | 0x61736963
+sensor_name_lo              | 0x00000000
+=========================================
+
+
+======================================================================
+COMMAND: mlxreg_ext -d lid-77 --reg_name MFCR --get
+======================================================================
+Sending access register...
+
+Field Name          | Data
+=================================
+pwm_frequency       | 0x00000000
+pwm_active          | 0x00000000
+tacho_active        | 0x00000000
+tacho_active_msb    | 0x00000000
+=================================
+
+
+======================================================================
+COMMAND: mlxreg_ext -d lid-77 --show_reg MFCR
+======================================================================
+Field Name          | Address (Bytes) | Offset (Bits) | Size (Bits) | Access
+=============================================================================
+pwm_frequency       | 0x00000000      | 0             | 7           | RW
+pwm_active          | 0x00000004      | 0             | 5           | RO
+tacho_active        | 0x00000004      | 16            | 10          | RO
+tacho_active_msb    | 0x00000004      | 26            | 6           | RO
+=============================================================================
+
+

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -171,7 +171,9 @@ run_tests_for_dump() {
         # The fixture encodes the literal string  "a\b"c  in the node
         # description hex blocks. Confirm round-trip integrity.
         if [[ "$js_parsed" != '"a\b"c' ]]; then
-            echo "FAILED (node_description round-trip mismatch: got '$js_parsed', expected '\"a\\b\"c')"
+            printf '%s\n'   'FAILED (node_description round-trip mismatch)'
+            printf '  got:      [%s]\n' "$js_parsed"
+            printf '%s\n'   '  expected: ["a\b"c]'
             return 1
         fi
         echo "OK ($validator)"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -130,6 +130,53 @@ run_tests_for_dump() {
         echo "OK"
     fi
 
+    # Test JSON output safety against special characters (Issue #3).
+    # The JSON-SPECIAL fixture has a node_description containing " and \,
+    # which would break naive interpolation. Verify the output parses as
+    # valid JSON and that the node_description round-trips intact.
+    if [[ "$(basename "$dump_file")" == "ibsw_dump_LID77_JSON-SPECIAL.txt" ]]; then
+        echo -n "  [JSON-safe] "
+        local js_out js_parsed
+        js_out=$("$REPO_DIR/ibswinfo.sh" -d "$device_arg" -o json 2>/dev/null)
+
+        # Pick a JSON validator: prefer jq, fall back to python3.
+        local validator=""
+        if command -v jq >/dev/null 2>&1; then
+            validator="jq"
+        elif command -v python3 >/dev/null 2>&1; then
+            validator="python3"
+        else
+            echo "SKIPPED (no jq or python3 available)"
+            return 0
+        fi
+
+        if [[ "$validator" == "jq" ]]; then
+            if ! echo "$js_out" | jq -e . >/dev/null 2>&1; then
+                echo "FAILED (jq could not parse JSON)"
+                echo "--- OUTPUT ---"
+                echo "$js_out"
+                return 1
+            fi
+            js_parsed=$(echo "$js_out" | jq -r .node_description)
+        else
+            if ! echo "$js_out" | python3 -c 'import json,sys; json.loads(sys.stdin.read())' 2>/dev/null; then
+                echo "FAILED (python3 could not parse JSON)"
+                echo "--- OUTPUT ---"
+                echo "$js_out"
+                return 1
+            fi
+            js_parsed=$(echo "$js_out" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["node_description"])')
+        fi
+
+        # The fixture encodes the literal string  "a\b"c  in the node
+        # description hex blocks. Confirm round-trip integrity.
+        if [[ "$js_parsed" != '"a\b"c' ]]; then
+            echo "FAILED (node_description round-trip mismatch: got '$js_parsed', expected '\"a\\b\"c')"
+            return 1
+        fi
+        echo "OK ($validator)"
+    fi
+
     return 0
 }
 


### PR DESCRIPTION
## Summary

Closes #3.

The `-o json` output built JSON by direct shell interpolation. Any field value containing `"`, `\`, or a control character produced malformed JSON that broke `jq`, the Prometheus exporters, and any downstream parser.

Since node descriptions are user-configurable via `-S`, a switch named `He said "hi"` would silently emit:

```json
{"node_description":"He said "hi"",...}
```

— invalid.

## Changes

| File | Change |
|------|--------|
| `ibswinfo.sh` | Add `json_escape()` helper (handles `\`, `"`, `\b \f \n \r \t`). Route every string field of the JSON output through it. Numeric fields are emitted as-is. |
| `tests/dumps/ibsw_dump_LID77_JSON-SPECIAL.txt` | New synthetic fixture: derived from the LID6 Sequana3 dump, with `node_description` rewritten to contain the literal bytes for `"a\b"c` (quote, backslash, second quote). |
| `tests/run_tests.sh` | New `[JSON-safe]` assertion: run `-o json` against the fixture, validate via `jq` (fallback to `python3`), and verify the `node_description` round-trips to its original bytes. |

## Test plan

- [x] `./tests/run_tests.sh` passes 7/7 dumps locally
- [x] New `[JSON-safe]` assertion: validates the JSON output is parsable AND that the special-char node_description round-trips intact
- [x] Verified manually that the JSON output is parseable by `jq` and that `jq -r .node_description` returns the original bytes
- [x] No regression on existing fixtures (the JSON output for them is unchanged: `json_escape` is a no-op on plain ASCII)

## Sample output

Before the fix (synthetic input `"a\b"c`):
```
{"node_description":""a\b"c",...}    # ← invalid JSON
```

After the fix:
```
{"node_description":"\"a\\b\"c",...}  # ← valid JSON
```