### PR TITLE
fix: reject empty -S argument to prevent partial node description writes

### DIFF
--- a/ibswinfo.sh
+++ b/ibswinfo.sh
@@ -390,6 +390,14 @@ while getopts "$optspec" optchar; do
             ;;
         S)
             desc=${OPTARG}
+            # An empty description must be rejected up-front: the write
+            # path below would otherwise leave node_description[0]
+            # uninitialized while zeroing slots [1]..[15], leaving the
+            # switch in an inconsistent state. If clearing a description
+            # is ever needed, that should be a dedicated explicit flag.
+            [[ -z "$desc" ]] && {
+                err "description string cannot be empty"
+            }
             [[ ${#desc} -gt $MAX_ND_LEN ]] && {
                 err "description string > $MAX_ND_LEN characters"
             }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -201,6 +201,26 @@ if [[ $count -eq 0 ]]; then
     exit 1
 fi
 
+# Global CLI-validation tests (dump-independent).
+echo "----------------------------------------------------------------"
+echo "=== Global CLI tests ==="
+
+# Issue #4: -S "" must be rejected up-front, before any device access,
+# to avoid leaving node_description[0] uninitialized on the switch.
+echo -n "  [empty -S]    "
+empty_s_out=$("$REPO_DIR/ibswinfo.sh" -S "" 2>&1)
+empty_s_rc=$?
+if [[ $empty_s_rc -eq 0 ]]; then
+    echo "FAILED (expected non-zero exit, got 0)"
+    global_status=1
+elif [[ "$empty_s_out" != *"description string cannot be empty"* ]]; then
+    echo "FAILED (expected 'description string cannot be empty' in stderr)"
+    echo "  got: [$empty_s_out]"
+    global_status=1
+else
+    echo "OK"
+fi
+
 echo "----------------------------------------------------------------"
 if [[ $global_status -eq 0 ]]; then
     echo "All tests passed successfully on $count dumps!"


### PR DESCRIPTION
## Summary

Closes #4.

The length check on `-S` only caught descriptions that were too long, not empty ones. Running `ibswinfo -d <device> -S ""` proceeded into the write path with an empty array, then left `node_description[0]` uninitialized while zeroing slots `[1]` through `[15]` — leaving the switch in an inconsistent state with a half-cleared name.

## Root cause

```bash
mapfile -t nd_arr < <(stoh "$desc")   # empty array
val="ndm=0x1"
for e in "${!nd_arr[@]}"; do          # loop never executes
    val+=",node_description[$e]=${nd_arr[$e]}"
done
((e+=1))                              # e was unset → bash arith = 0+1 = 1
while [[ $e -le 15 ]]; do             # zeros [1]..[15], skips [0]
    val+=",node_description[$e]=0x00000000"
    ((e+=1))
done
```

## Fix

Add an explicit `[[ -z "$desc" ]]` check inside the `-S` option handler so the empty case fails early with a clear message. If clearing a description ever becomes a real use case, that should be a dedicated flag, not an empty `-S`.

## Test plan

- [x] New global CLI test `[empty -S]` in `tests/run_tests.sh`:
  - asserts exit code is non-zero
  - asserts stderr contains `description string cannot be empty`
- [x] Manual verification:
  - `./ibswinfo.sh -S ""` → `exit 1`, stderr: `error: description string cannot be empty`
  - `./ibswinfo.sh -S "valid name"` → passes validation (proceeds to next checks)
- [x] All 7 dump tests still pass (no regression)