### PR TITLE
release: v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.1] - 2026-04-27
+
+### Fixed
+- **Graceful handling of unsupported registers on older firmware (#1, #6).** Switches whose firmware cannot serve some MFT registers (typically returning `-E- FW burnt on device does not support generic access register`) no longer cause the script to abort with `exit 1`. The script now warns on stderr and continues with empty data for the unavailable register; downstream parsing already tolerates missing values. Resolves the long-standing integration failure with `infiniband_exporter` where affected switches produced no metrics at all.
+- **Dependency check uses correct MFT binary names (#2, #7).** The startup check now looks for `mlxreg_ext` (what the script actually calls) instead of the legacy `mlxreg`. Recent MFT releases ship `mlxreg_ext` only, so the previous check was a false positive. The unused `smpquery` dependency has also been removed.
+- **JSON output now properly escapes special characters (#3, #8).** A new `json_escape()` helper neutralizes backslashes, double quotes, and standard control characters in every string value. Previously, a switch with a node description containing `"` or `\` produced invalid JSON that broke `jq`, Prometheus exporters, and any downstream parser.
+- **Empty `-S` argument is rejected (#4, #9).** Running `ibswinfo -d <device> -S ""` no longer corrupts the node description: it left `node_description[0]` untouched while zeroing slots `[1]`..`[15]`. The empty case now fails fast with a clear error message.
+
+### Added
+- New test fixtures in `tests/dumps/`:
+  - `ibsw_dump_LID6_Sequana3-IB400.txt`: real-hardware dump from a Bull/Atos Sequana3 chassis switch (PSID `BL_12002101`, MFT 4.32.0). First HDR400 OEM and chassis-managed fixture in the suite.
+  - `ibsw_dump_LID42_FW-LIMITED.txt`: synthetic fixture for the unsupported-register error path (Issue #1).
+  - `ibsw_dump_LID77_JSON-SPECIAL.txt`: synthetic fixture with `"` and `\` in `node_description` for JSON-safety testing (Issue #3).
+- New explicit test assertions in `tests/run_tests.sh`: `[FW-burnt]`, `[JSON-safe]` (with `jq` / `python3` fallback), and `[empty -S]`.
+
+### Changed
+- `tests/bin/mlxreg_ext` mock: error blocks (`-E-`) are now correctly propagated to the caller. Previously, a bug in the mock's `awk` parser silently swallowed them, hiding the unsupported-register failure mode from the test suite.
+
+### Hardware coverage
+- **Tested** (real-hardware dumps in `tests/dumps/`): MQM8790 Quantum HDR, MQM9790 Quantum2 NDR, Sequana3 Unmng IB 400 (Bull/Atos OEM, HDR400, water-cooled chassis-integrated).
+
 ## [0.8] - 2026-01-14 (Forked Version)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,14 +84,24 @@ the NVIDIA Software Tools service, or by LID.
   as 0_)
 * SB7890 Switch-IB2 (EDR)
 * QM8790 Quantum (HDR)
+* QM9790 Quantum2 (NDR)
+* Sequana3 Unmng IB 400 (Bull/Atos OEM, HDR400, water-cooled chassis-integrated)
 
 Limited support is also available for the managed version of those switches:
 * SB7800 Switch-IB2 (EDR)
 * QM8700 Quantum (HDR)
 
 > [!NOTE]
+> Chassis-integrated switches (e.g. Sequana3) are powered through a chassis-level
+> sideband and have no local PSUs. The MSPS register returns all-zero blocks on
+> these models, which the current PSU decoder reports as `PSU0/1 status: ERROR`.
+> This is expected behavior — the chassis power supplies are managed by the
+> chassis controller (HMC/BMC), not the switch firmware. A nicer "N/A
+> (chassis-managed)" output is on the roadmap (see issue #5).
+
+> [!NOTE]
 > If you find other working models, please feel free to open an
-[issue](https://github.com/stanford-rc/ibswinfo/issues/new) and
+[issue](https://github.com/SckyzO/ibswinfo/issues/new) and
 we'll complete the list.
 
 
@@ -136,6 +146,23 @@ Misc:
   -v                      show version
   -h                      show this help
 ```
+
+### New in v0.8.1
+
+*   **Resilience to older firmwares:** Switches whose firmware does not
+    support some MFT registers (typically returning `FW burnt on device does
+    not support generic access register`) no longer cause the script to abort.
+    The script now warns on stderr and continues with whatever data it could
+    read. This fixes `infiniband_exporter` integration on heterogeneous
+    fleets where some switches have limited firmware capabilities.
+*   **Safer JSON output:** the `-o json` output now properly escapes special
+    characters (`"`, `\`, control characters) in field values. Previously,
+    a switch with a node description containing a quote produced invalid JSON.
+*   **Cleaner dependency check:** the script now correctly looks for
+    `mlxreg_ext` (instead of the legacy `mlxreg`) and no longer requires
+    `smpquery` (which was unused).
+*   **Stricter `-S` validation:** running `-S ""` is now rejected up-front
+    instead of silently leaving the switch's name half-cleared.
 
 ### New in v0.8
 

--- a/ibswinfo.sh
+++ b/ibswinfo.sh
@@ -22,7 +22,7 @@ set -u      # stop on uninitialized variable
 
 MFT_URL="https://www.mellanox.com/products/adapter-software/firmware-tools"
 MAX_ND_LEN=64
-VERSION="0.8"
+VERSION="0.8.1"
 
 # UI Constants
 C_R=$'\033[0;31m'  # Red


### PR DESCRIPTION
## Summary

Patch release bundling four critical bugfixes for production use with `infiniband_exporter`.

## Included fixes

| Issue | PR | Description |
|-------|-----|------------|
| #1 | #6 | Graceful handling of unsupported registers on older firmware (the FW burnt error) |
| #2 | #7 | Dependency check uses correct MFT binary names (`mlxreg_ext` not `mlxreg`, drop unused `smpquery`) |
| #3 | #8 | JSON output properly escapes special characters |
| #4 | #9 | Reject empty `-S` argument to prevent partial node description writes |

## Release artifacts

This PR only bumps `VERSION`, updates `CHANGELOG.md`, and updates `README.md`. No code changes — those landed in the four fix PRs above.

When this PR is merged and the tag `v0.8.1` is pushed, `.github/workflows/release.yml` will:
- Create a GitHub Release named `v0.8.1`
- Auto-generate release notes
- Attach `ibswinfo.sh` as a downloadable asset

## Test plan

- [x] `./tests/run_tests.sh` passes 7/7 dumps
- [x] `./ibswinfo.sh -v` returns `ibswinfo version 0.8.1`
- [x] CHANGELOG follows the existing Keep-a-Changelog format
- [x] README hardware list reflects coverage actually backed by fixtures