### PR TITLE
chore: bash hygiene and code quality cleanup

### DIFF
--- a/ibswinfo.sh
+++ b/ibswinfo.sh
@@ -15,8 +15,9 @@
 #
 #==============================================================================
 
-set -e      # stop on error
-set -u      # stop on uninitialized variable
+set -e              # stop on error
+set -u              # stop on uninitialized variable
+set -o pipefail     # propagate pipeline failures (any stage, not just last)
 
 ## -- constants ---------------------------------------------------------------
 
@@ -110,7 +111,7 @@ htos() {
     local h=$*
     local s
     s=$(sed 's/0x\|[[:space:]]//g; s/\(..\)/\\x\1/g' <<< "$h")
-    printf "%b\n" "$s" | tr -d \\0
+    printf "%b\n" "$s" | tr -d '\0'
 }
 
 # string to hex array (split and padded)
@@ -402,9 +403,9 @@ while getopts "$optspec" optchar; do
                 err "description string > $MAX_ND_LEN characters"
             }
             ;;
-	y)
+        y)
             opt_y=1
-	    ;;
+            ;;
     esac
 done
 
@@ -454,7 +455,7 @@ if [[ -z "$dev" && "$opt_A" == "1" ]]; then
 fi
 
 # drop -T for inventory/status outputs
-[[ "$out" =~ inventory|status ]] && opt_T=0
+[[ "$out" =~ ^(inventory|status)$ ]] && opt_T=0
 
 # check conflicting options
 [[ -n "$desc" ]] && [[ -n "$out" || "$opt_T" -eq 1 ]] && {
@@ -485,7 +486,6 @@ mft_cur=$(mst version | awk '{gsub(/,/,""); print $3}' | cut -d- -f1)
 mft_req="4.18.0"      # minimum required MFT version
 mft_req_desc="4.22.0" # minimum required MFT version to set device name
 mft_max="4.33.0"      # highest MFT version tested
-mft_cur=$(mst version | awk '{gsub(/,/,""); print $3}' | cut -d- -f1)
 [[ ${mft_cur//./} -lt ${mft_req//./} ]] && \
     err "MFT version must be >= $mft_req (current version is $mft_cur)"
 [[ "$desc" != "" ]] && [[ ${mft_cur//./} -lt ${mft_req_desc//./} ]] && \
@@ -499,7 +499,7 @@ mft_cur=$(mst version | awk '{gsub(/,/,""); print $3}' | cut -d- -f1)
 [[ ${dev:0:4} != "lid-" ]] && {
     [[ ${dev:0:8} == '/dev/mst' ]] && dev=${dev/\/dev\/mst\//}
     [[ ${dev:0:3} == "SW_" ]] || err "$dev doesn't look like a switch device name"
-    [[ -r /dev/mst/$dev ]] || err "$dev not found in /dev/mst, is mst started?"
+    [[ -r "/dev/mst/$dev" ]] || err "$dev not found in /dev/mst, is mst started?"
 }
 
 
@@ -585,7 +585,7 @@ done <<< "$_regs"
     echo "  Current node description: $cur_nd"
     echo "  Set node description to : $desc"
     [[ "$opt_y" == "0" ]] && {
-        read -p ">> Confirm? (y/N) " -n 1 -r
+        read -r -p ">> Confirm? (y/N) " -n 1
         echo
         [[ $REPLY =~ ^[Yy]$ ]] || exit 1
     }
@@ -620,7 +620,10 @@ done <<< "$_regs"
 # extract data from register values
 # inventory
 [[ ! "$out" =~ status|vitals ]] && {
-    # part/serial number
+    # part/serial number. The "roduct_name" pattern (missing leading "p")
+    # is intentional: mstr_dec uses regex matching, so this matches
+    # "product_name" without conflicting with "manufacturing_..." or
+    # similar prefixed fields.
     pn=$(mstr_dec "part_number"   MSGI)
     sn=$(mstr_dec "serial_number" MSGI)
     cn=$(mstr_dec "roduct_name"   MSGI)
@@ -638,7 +641,6 @@ done <<< "$_regs"
     cpld=$(htod "$(awk '/^version / {printf $NF}' <<< "${reg[MSCI]}")")
 
     # node description
-    #shellcheck disable=SC2046
     nd=$(mstr_dec "node_description" SPZR)
     guid=$(awk '/^node_guid/ {gsub(/0x/,"",$NF); g=g$NF} END {print "0x"g}' \
           <<< "${reg[SPZR]}")

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -93,6 +93,49 @@ run_tests_for_dump() {
         return 1
     fi
 
+    # Test infiniband_exporter compatibility.
+    # The exporter (collectors/ibswinfo.go in treydock/infiniband_exporter)
+    # invokes the script with `-d lid-<N>` (no -o flag) and parses the
+    # default key|value table. Any change to the default output format
+    # MUST keep these key prefixes intact, or the exporter silently loses
+    # metrics. This test guards the contract.
+    #
+    # The exporter uses prefix matching (e.g. "uptime" matches the actual
+    # key "uptime (d-h:m:s)"), so we do the same here: split each line on
+    # "|", trim the first field, and check it starts with the expected key.
+    echo -n "  [exporter]  "
+    local ec_out ec_missing=()
+    ec_out=$("$REPO_DIR/ibswinfo.sh" -d "$device_arg" 2>/dev/null)
+    local ec_keys=(
+        'part number'
+        'serial number'
+        'PSID'
+        'firmware version'
+        'uptime'
+        'temperature (C)'
+        'fan status'
+    )
+    local k k_found
+    for k in "${ec_keys[@]}"; do
+        k_found=$(awk -F'|' -v k="$k" '
+            {
+                key = $1
+                gsub(/^[ \t]+|[ \t]+$/, "", key)
+                if (index(key, k) == 1) { print "yes"; exit }
+            }
+        ' <<< "$ec_out")
+        if [[ "$k_found" != "yes" ]]; then
+            ec_missing+=("$k")
+        fi
+    done
+    if [[ ${#ec_missing[@]} -gt 0 ]]; then
+        echo "FAILED (missing exporter-required keys: ${ec_missing[*]})"
+        echo "--- DEFAULT OUTPUT ---"
+        echo "$ec_out"
+        return 1
+    fi
+    echo "OK"
+
     # Test graceful handling of unsupported registers (Issue #1).
     # The FW-LIMITED fixture intentionally injects "-E- FW burnt..." on MSCI;
     # the script must exit 0, emit a warning on stderr, and still produce


### PR DESCRIPTION
## Summary

Mechanical bash hygiene pass for `v0.9.0`. References the umbrella issue #5 (P2 items).

**Critical: preserves full backward compatibility with `infiniband_exporter`.** A new dedicated assertion in `tests/run_tests.sh` (commit 1) explicitly guards the default output contract before any change is applied (commit 2).

## Items addressed (from umbrella #5)

- [x] Mixed tab/space indentation in `case y)` (P2)
- [x] Missing regex anchors in `[[ "$out" =~ inventory\|status ]]` (P2)
- [x] Add `set -o pipefail` (P2)
- [x] Unquoted `$dev` in `[[ -r /dev/mst/$dev ]]` (P1)
- [x] `tr -d \\0` quoting (P2)
- [x] Duplicate `mft_cur` computation (P1)
- [x] `read -p` flag order (P1)
- [x] Undocumented `roduct_name` regex trick (P2)
- [x] `#shellcheck disable=SC2046` without justification (P2)

## Out of scope (handled in later PRs)

- Race condition in parallel register gathering — PR C
- `atlsb_bmsz`/`atmsb_bmsz` from cached MFCR — PR B
- Naive version comparison — PR E
- EOF in interactive prompt — PR E
- `htos` UTF-8 — TBD
- PSU bitmask "guessing" — to be addressed alongside the chassis-managed PSU UX (PR D)

## Test plan

- [x] **New `[exporter]` assertion** added on a separate commit BEFORE any change, asserts that the default output contains all keys the exporter parses: `part number`, `serial number`, `PSID`, `firmware version`, `uptime`, `temperature (C)`, `fan status`. Uses prefix matching like the exporter does. Runs on all 7 dump fixtures.
- [x] All 7 dumps pass `./tests/run_tests.sh` after every change
- [x] `set -o pipefail` was added incrementally and tested separately — no regressions
- [x] Manual sanity check: `./ibswinfo.sh -d lid-21` against the 4.26.1 fixture produces the same human-readable table as before

## Commits

1. `test: add infiniband_exporter compatibility assertion` — guards the contract
2. `chore: bash hygiene and code quality cleanup` — applies the changes