### PR TITLE
feat: detect chassis-managed switches and report PSU as N/A

### DIFF
--- a/ibswinfo.sh
+++ b/ibswinfo.sh
@@ -720,6 +720,23 @@ done <<< "$_regs"
 #shellcheck disable=SC2001
 psu_idxs=$(sed 's/.*psu\([0-9]\).*/\1/;t;d' <<< "${reg[MSPS]}" | sort -u)
 declare -A ps
+
+# Detect chassis-managed switches: MSPS reports valid psu blocks but every
+# field is 0x00000000 because the switch is sideband-fed from the chassis
+# and has no local PSUs. Without this guard, the bitmask decoder below
+# would label every imaginary PSU as "ERROR", which is misleading on
+# water-cooled / chassis-integrated hardware (e.g. Sequana3). Skip the
+# per-PSU loop and let the output paths emit a single "N/A" line instead.
+chassis_managed=0
+if [[ -n "$psu_idxs" ]]; then
+    psu_nonzero=$(awk '/^psu[0-9]+\[/ && $NF != "0x00000000" {n++}
+                       END {print n+0}' <<< "${reg[MSPS]}")
+    if [[ "$psu_nonzero" -eq 0 ]]; then
+        chassis_managed=1
+        psu_idxs=""
+    fi
+fi
+
 for i in $psu_idxs; do
     # get PSU status bitmasks, a lot of guessing is taking place here
     for j in 0 1; do
@@ -772,6 +789,7 @@ case $out in
                 out_kv "psu$i.serial" "${ps[$i.sn]}"
             done
         }
+        [[ "$chassis_managed" == "1" ]] && out_kv "psu" "N/A (chassis-managed)"
         exit 0
         ;;
 
@@ -783,6 +801,7 @@ case $out in
                 out_kv "psu$i.fan"     "${ps[$i.fs]}"
             done
         }
+        [[ "$chassis_managed" == "1" ]] && out_kv "psu" "N/A (chassis-managed)"
         out_kv "fans" "$fa"
         exit 0
         ;;
@@ -795,6 +814,7 @@ case $out in
                 out_kv "psu$i.power (W)" "${ps[$i.wt]}"
             done
         }
+        [[ "$chassis_managed" == "1" ]] && out_kv "psu.power (W)" "N/A"
         out_kv "cur.temp (C)" "${tp}"
         out_kv "max.temp (C)" "${mt}"
         [[ "$opt_T" == "1" ]] && {
@@ -831,7 +851,9 @@ case $out in
             echo -n ",\"serial\":\"$(json_escape "${ps[$i.sn]}")\"}"
             first=0
         done
-        echo -n "]},\"status\":{\"fans\":\"$(json_escape "$fa")\",\"psus\":["
+        echo -n "]},\"status\":{\"fans\":\"$(json_escape "$fa")\""
+        [[ "$chassis_managed" == "1" ]] && echo -n ",\"chassis_managed\":true"
+        echo -n ",\"psus\":["
         first=1
         for i in $psu_idxs; do
             [[ $first -eq 0 ]] && echo -n ","
@@ -944,6 +966,8 @@ case $out in
             done
             print_line "" $DASH_WIDTH
             print_line "   Total Power Consumption: $total_w W" $DASH_WIDTH
+        elif [[ "$chassis_managed" == "1" ]]; then
+            print_line "   $(status_block INFO)  N/A — chassis-managed (no local PSUs)" $DASH_WIDTH
         else
             print_line "   PSU: data unavailable" $DASH_WIDTH
         fi
@@ -1085,6 +1109,10 @@ sep
         out_kv "     fan status" "${ps[$i.fs]}"
         out_kv "     power (W)"  "${ps[$i.wt]}"
     done
+    sep
+}
+[[ "$chassis_managed" == "1" ]] && {
+    out_kv "PSU" "N/A (chassis-managed)"
     sep
 }
 out_kv "temperature (C)" "${tp}"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -136,6 +136,49 @@ run_tests_for_dump() {
     fi
     echo "OK"
 
+    # Test chassis-managed PSU detection (PR D, v0.9.0).
+    # The Sequana3 fixture has MSPS returning all-zero psu blocks because
+    # the switch is sideband-fed from the chassis with no local PSUs.
+    # The script must report "N/A (chassis-managed)" instead of producing
+    # bogus PSU-ERROR lines, AND must NOT emit "PSU<N> status" lines that
+    # the exporter would consume as real metrics.
+    if [[ "$(basename "$dump_file")" == "ibsw_dump_LID6_Sequana3-IB400.txt" ]]; then
+        echo -n "  [chassis]   "
+        local cm_default cm_status cm_json
+        cm_default=$("$REPO_DIR/ibswinfo.sh" -d "$device_arg" 2>/dev/null)
+        cm_status=$("$REPO_DIR/ibswinfo.sh" -d "$device_arg" -o status 2>/dev/null)
+        cm_json=$("$REPO_DIR/ibswinfo.sh" -d "$device_arg" -o json 2>/dev/null)
+
+        # 1. Default output should show the chassis-managed line, NOT the
+        #    misleading per-PSU ERROR breakdown.
+        if [[ "$cm_default" != *"PSU                | N/A (chassis-managed)"* ]]; then
+            echo "FAILED (default output missing 'PSU | N/A (chassis-managed)' line)"
+            return 1
+        fi
+        if grep -qE "^PSU[0-9]+ status" <<< "$cm_default"; then
+            echo "FAILED (default output still emits per-PSU status lines)"
+            return 1
+        fi
+
+        # 2. -o status should also report chassis, no per-PSU rows.
+        if [[ "$cm_status" != *"psu                : N/A (chassis-managed)"* ]]; then
+            echo "FAILED (-o status missing chassis-managed line)"
+            return 1
+        fi
+
+        # 3. JSON should have chassis_managed=true and empty psus array.
+        if command -v jq >/dev/null 2>&1; then
+            local cm_flag cm_psu_count
+            cm_flag=$(jq -r '.status.chassis_managed' <<< "$cm_json")
+            cm_psu_count=$(jq -r '.status.psus | length' <<< "$cm_json")
+            if [[ "$cm_flag" != "true" || "$cm_psu_count" != "0" ]]; then
+                echo "FAILED (JSON: chassis_managed=$cm_flag, psus.length=$cm_psu_count)"
+                return 1
+            fi
+        fi
+        echo "OK"
+    fi
+
     # Test graceful handling of unsupported registers (Issue #1).
     # The FW-LIMITED fixture intentionally injects "-E- FW burnt..." on MSCI;
     # the script must exit 0, emit a warning on stderr, and still produce


### PR DESCRIPTION
## Summary

Refs #5 (umbrella).

On chassis-integrated switches like the Bull/Atos Sequana3 (water-cooled HDR400, PSID `BL_12002101`), the switch is sideband-fed from the chassis and has no local PSUs. MSPS returns valid blocks but every field is `0x00000000`. The current PSU bitmask decoder reads those zeros as "PSU absent" and produces this misleading default output:

```
PSU0 status        | ERROR
     DC power      | ERROR
     fan status    | ERROR
PSU1 status        | ERROR
     DC power      | ERROR
     fan status    | ERROR
```

— even though the switch is healthy.

## Approach

Detection is **hardware-agnostic**: when MSPS returns valid `psuN[*]` blocks but every value is zero, treat as chassis-managed. No PSID hardcoding, so any future vendor with the same topology gets the same handling automatically.

## Behaviour change

| Output | Before | After |
|--------|--------|-------|
| Default | 6 lines of `PSU<N> status: ERROR` | One line `PSU | N/A (chassis-managed)` |
| `-o status` | Same as above | `psu : N/A (chassis-managed)` |
| `-o vitals` | `psu0.power (W) | ` (empty) | `psu.power (W) : N/A` |
| `-o json` | `"psus":[ERROR objects]` | `"chassis_managed":true, "psus":[]` |
| `-o dashboard` | PSU bars showing fake PSU 0 with red status | INFO-coloured `N/A — chassis-managed (no local PSUs)` block |

## infiniband_exporter compatibility

**Critical:** the new `PSU` line in default output deliberately does NOT match the exporter's `PSU([0-9]) status` regex (no digit before "status"). Result: the exporter sees no PSU info for chassis-managed switches and emits no `power_supply_*` metrics for them — which matches reality (the chassis controller owns that data, queried separately via IPMI/Redfish).

The existing `[exporter]` assertion still passes, confirming the contract is preserved.

## Test plan

- [x] New `[chassis]` assertion on the Sequana3 fixture validates:
  - default output contains the chassis-managed line AND not the per-PSU rows
  - `-o status` reports chassis-managed
  - JSON has `chassis_managed: true` and empty `psus`
- [x] All 7 dump fixtures pass (`./tests/run_tests.sh`)
- [x] Air-cooled switches with valid MSPS data are unchanged (verified on QM8790 and QM9790 fixtures)
- [x] `[exporter]` assertion still passes (no break of the parsing contract)

## Sample output (Sequana3, after fix)

```
=================================================
 iswr2s19
=================================================
part number        | 11891122
serial number      | J0251601J
product name       | Sequana3 Unmng IB 400
...
-------------------------------------------------
PSU                | N/A (chassis-managed)
-------------------------------------------------
temperature (C)    | 66
...
```

```json
{
  "status": {
    "fans": "OK",
    "chassis_managed": true,
    "psus": []
  }
}
```