### PR TITLE
fix: race condition in parallel register reads

### DIFF
--- a/ibswinfo.sh
+++ b/ibswinfo.sh
@@ -554,14 +554,33 @@ rid[MSCI]+="index=0x0" # handle main CPLD only
 rid[SPZR]+="swid=0x0"
 rid[MTMP]+="sensor_index=0x0${add_idx:+,$add_idx}${add_tmp_idx:+,$add_tmp_idx}"
 rid[MTCAP]="$add_idx"
-# get registers
-_regs=$(for r in $reg_names; do
-            echo "$r" "$(get_reg "$r" "${rid[$r]:-}" |& paste -s -d '@')" &
-        done)
+# Read registers in parallel, but isolate each register's output in its
+# own temp file. The previous design captured the parallel subshells'
+# combined stdout into a single variable, joined per-register via
+# `paste -s -d '@'`. That joined "line" routinely exceeded PIPE_BUF
+# (~4 KiB on Linux) for verbose registers like MGIR (~100 fields), so
+# concurrent writes from sibling subshells could interleave bytes
+# inside the captured output. The corruption was silent — the affected
+# register's content showed up garbled (or empty) in `reg[]`, and the
+# downstream awks would just fail to match and produce empty fields.
+# Symptom: ~25% of test runs failed with "Part Number not found",
+# random across MSGI/MGIR/SPZR. With per-file isolation each register
+# gets its own write path, so atomicity is no longer a concern.
+# Prefix the tempdir name so leftover dirs from a kill -9 (trap doesn't
+# fire) are easy to identify and reap with e.g.
+#   find /tmp -maxdepth 1 -name 'ibswinfo-*' -mtime +1 -delete
+reg_tmpdir=$(mktemp -d -t ibswinfo-XXXXXX)
+trap 'rm -rf "$reg_tmpdir"' EXIT
+
+for r in $reg_names; do
+    get_reg "$r" "${rid[$r]:-}" > "$reg_tmpdir/$r" 2>&1 &
+done
+wait
+
 # store them
-for r in $reg_names; do reg[$r]=""; done
-while read -r r v; do
-    o=${v//@/$'\n'}
+for r in $reg_names; do
+    reg[$r]=""
+    o=$(< "$reg_tmpdir/$r")
     if [[ "$o" =~ -E- ]] && [[ $r != MGPIR ]]; then
         # Register read failed (firmware does not support it, MFT version
         # mismatch, missing index, etc.). Warn and skip; downstream parsing
@@ -573,7 +592,10 @@ while read -r r v; do
         continue
     fi
     reg[$r]=$o
-done <<< "$_regs"
+done
+
+rm -rf "$reg_tmpdir"
+trap - EXIT
 
 
 ## -- node description mgmt ---------------------------------------------------


### PR DESCRIPTION
## Summary

Refs #5 (umbrella).

The script reads ~10 MFT registers in parallel. The current implementation captures the parallel subshells' combined stdout into a single variable, joining per-register output via \`paste -s -d '@'\`. That joined "line" routinely exceeds \`PIPE_BUF\` (~4 KiB on Linux) for verbose registers like MGIR (~100 fields), so concurrent writes from sibling subshells lose atomicity and bytes from different registers can interleave inside the captured output.

The corruption is **silent**: the affected register's content shows up garbled (or empty) in \`reg[]\`, downstream awks fail to match, and fields like \`part_number\` end up empty.

## How it was discovered

PR #11 (code quality cleanup) dropped two \`show_reg MFCR\` calls. Without them, the script ran fast enough to expose the race: the test suite started failing ~25-33% of runs with random "Part Number not found" / "missing exporter-required keys" errors — even on \`main\`. Empirical measurement on this machine, 24 runs each:

| Configuration | Failure rate |
|---|---|
| parallel + paste (main today) | 25.0% (6/24) |
| parallel + paste + PR B refactor | 33.3% (8/24) |
| serialized (no \`&\`) | **0.0%** (0/24) |
| **parallel + tempfiles (this PR)** | **0.0%** (0/24) |

The "serialized" experiment proved the diagnosis: the race is in the parallel write path, not anywhere else.

## Why this matters at scale

\`infiniband_exporter\` scrapes every device on every interval. With 200 switches at 30 s scrape and the default \`max-concurrent=1\`:

- 200 × 2 (scrapes/min) × 60 × 24 = **576 000 ibswinfo invocations / day**
- 25 % race rate = **~144 000 silently-corrupted scrapes / day**

Hard to spot in metrics — looks like the switch occasionally "loses" a field — but absolutely real.

## Fix

Each parallel subshell writes to its own temp file. We \`wait\` for them, then read the files back in order. No atomicity assumption needed.

\`\`\`bash
reg_tmpdir=\$(mktemp -d -t ibswinfo-XXXXXX)
trap 'rm -rf "\$reg_tmpdir"' EXIT

for r in \$reg_names; do
    get_reg "\$r" "\${rid[\$r]:-}" > "\$reg_tmpdir/\$r" 2>&1 &
done
wait

for r in \$reg_names; do
    o=\$(< "\$reg_tmpdir/\$r")
    # ... existing -E- handling ...
    reg[\$r]=\$o
done

rm -rf "\$reg_tmpdir"
trap - EXIT
\`\`\`

Throughput is preserved (~200 ms per invocation, parallel reads); we avoid the ~1-2 s slowdown of full serialization that would have been the simpler alternative.

## Edge cases

- **Tempdir naming**: prefixed with \`ibswinfo-\` so leftover dirs from a \`kill -9\` (where the trap doesn't fire) are easily identifiable. Reap with \`find /tmp -maxdepth 1 -name 'ibswinfo-*' -mtime +1 -delete\`.
- **Disk usage**: ~40 KB per invocation (10 files × ~4 KB). Cleaned up by the trap on normal exit, errors under \`set -e\`, and standard signals.
- **Concurrent invocations**: each \`mktemp -d\` produces a unique path, so 20 concurrent ibswinfos = 20 isolated dirs.
- **\`/tmp\` on tmpfs**: even faster than disk; no measurable cost.

## Test plan

- [x] All 7 dump fixtures pass (\`./tests/run_tests.sh\`)
- [x] **24 consecutive runs**: 0/24 failures (down from 6-8/24 before)
- [x] No leftover \`/tmp/ibswinfo-*\` after normal runs (trap fires correctly)
- [x] \`[exporter]\` compatibility assertion still passes
- [x] Output format unchanged on all paths (default, JSON, dashboard, status, vitals, inventory)