### PR TITLE
chore: redact serial numbers, MACs and GUIDs in test fixtures

### DIFF
--- a/tests/dumps/ibsw_dump_4.26.1_MQM8790.txt
+++ b/tests/dumps/ibsw_dump_4.26.1_MQM8790.txt
@@ -26,7 +26,7 @@ hw_dev_id                       | 0x0000024d
 manufacturing_base_mac_47_32    | 0x0000a088
 ga                              | 0x00000000
 chip_type                       | 0x00000000
-manufacturing_base_mac_31_0     | 0xc25f3d76
+manufacturing_base_mac_31_0     | 0xab12cd34
 uptime                          | 0x006c3edc
 sub_minor                       | 0x00000000
 minor                           | 0x00000000
@@ -145,9 +145,9 @@ Sending access register...
 
 Field Name          | Data    
 =================================
-serial_number[0]    | 0x4d543233
-serial_number[1]    | 0x33355430
-serial_number[2]    | 0x30423233
+serial_number[0]    | 0x4d543234
+serial_number[1]    | 0x30305430
+serial_number[2]    | 0x30414243
 serial_number[3]    | 0x00000000
 serial_number[4]    | 0x00000000
 serial_number[5]    | 0x00000000
@@ -205,9 +205,9 @@ psu0[0]     | 0x50000010
 psu0[1]     | 0x00000002
 psu0[2]     | 0x800000bb
 psu0[3]     | 0x00000001
-psu0[4]     | 0x4d543233
-psu0[5]     | 0x33355430
-psu0[6]     | 0x30335436
+psu0[4]     | 0x4d543234
+psu0[5]     | 0x30305430
+psu0[6]     | 0x30305031
 psu0[7]     | 0x00000000
 psu0[8]     | 0x00000000
 psu0[9]     | 0x00000000
@@ -225,9 +225,9 @@ psu1[0]     | 0x50000010
 psu1[1]     | 0x00000002
 psu1[2]     | 0x800000a4
 psu1[3]     | 0x00000001
-psu1[4]     | 0x4d543233
-psu1[5]     | 0x33355430
-psu1[6]     | 0x30335437
+psu1[4]     | 0x4d543234
+psu1[5]     | 0x30305430
+psu1[6]     | 0x30305032
 psu1[7]     | 0x00000000
 psu1[8]     | 0x00000000
 psu1[9]     | 0x00000000

--- a/tests/dumps/ibsw_dump_4.33.0_MQM9790.txt
+++ b/tests/dumps/ibsw_dump_4.33.0_MQM9790.txt
@@ -28,7 +28,7 @@ development                     | 0x00000000
 manufacturing_base_mac_47_32    | 0x0000b0cf
 ga                              | 0x00000000
 chip_type                       | 0x00000000
-manufacturing_base_mac_31_0     | 0x0ecc0480
+manufacturing_base_mac_31_0     | 0x0eab1234
 device_ticks_per_msec           | 0x00000000
 uptime                          | 0x003e4785
 sub_minor                       | 0x00000000
@@ -158,8 +158,8 @@ Sending access register...
 Field Name          | Data
 =================================
 serial_number[0]    | 0x4d543234
-serial_number[1]    | 0x34315430
-serial_number[2]    | 0x30344636
+serial_number[1]    | 0x30315430
+serial_number[2]    | 0x30444546
 serial_number[3]    | 0x00000000
 serial_number[4]    | 0x00000000
 serial_number[5]    | 0x00000000
@@ -221,11 +221,11 @@ router_entity           | 0x00000000
 swid                    | 0x00000000
 capability_mask         | 0xe550d848
 system_image_guid_h     | 0xb0cf0e03
-system_image_guid_l     | 0x00cc0480
+system_image_guid_l     | 0x00ab1234
 guid0_h                 | 0xb0cf0e03
-guid0_l                 | 0x00cc0480
+guid0_l                 | 0x00ab1234
 node_guid_h             | 0xb0cf0e03
-node_guid_l             | 0x00cc0480
+node_guid_l             | 0x00ab1234
 capability_mask2        | 0x0000043b
 max_pkey                | 0x00000008
 node_description[0]     | 0x69737772
@@ -259,8 +259,8 @@ psu0[1]     | 0x00000002
 psu0[2]     | 0x80000124
 psu0[3]     | 0x00000001
 psu0[4]     | 0x4d543234
-psu0[5]     | 0x34315430
-psu0[6]     | 0x30314630
+psu0[5]     | 0x30315430
+psu0[6]     | 0x30305031
 psu0[7]     | 0x00000000
 psu0[8]     | 0x00000000
 psu0[9]     | 0x00000000
@@ -279,8 +279,8 @@ psu1[1]     | 0x00000002
 psu1[2]     | 0x8000012c
 psu1[3]     | 0x00000001
 psu1[4]     | 0x4d543234
-psu1[5]     | 0x34315430
-psu1[6]     | 0x30314554
+psu1[5]     | 0x30315430
+psu1[6]     | 0x30305032
 psu1[7]     | 0x00000000
 psu1[8]     | 0x00000000
 psu1[9]     | 0x00000000

--- a/tests/dumps/ibsw_dump_LID0_MQM9790-NS2F.txt
+++ b/tests/dumps/ibsw_dump_LID0_MQM9790-NS2F.txt
@@ -30,7 +30,7 @@ development                     | 0x00000000
 manufacturing_base_mac_47_32    | 0x0000b0cf
 ga                              | 0x00000000
 chip_type                       | 0x00000000
-manufacturing_base_mac_31_0     | 0x0ecc0480
+manufacturing_base_mac_31_0     | 0x0eab1234
 device_ticks_per_msec           | 0x00000000
 uptime                          | 0x003ecec2
 sub_minor                       | 0x00000000
@@ -160,8 +160,8 @@ Sending access register...
 Field Name          | Data    
 =================================
 serial_number[0]    | 0x4d543234
-serial_number[1]    | 0x34315430
-serial_number[2]    | 0x30344636
+serial_number[1]    | 0x30315430
+serial_number[2]    | 0x30444546
 serial_number[3]    | 0x00000000
 serial_number[4]    | 0x00000000
 serial_number[5]    | 0x00000000
@@ -223,11 +223,11 @@ router_entity           | 0x00000000
 swid                    | 0x00000000
 capability_mask         | 0xe550d848
 system_image_guid_h     | 0xb0cf0e03
-system_image_guid_l     | 0x00cc0480
+system_image_guid_l     | 0x00ab1234
 guid0_h                 | 0xb0cf0e03
-guid0_l                 | 0x00cc0480
+guid0_l                 | 0x00ab1234
 node_guid_h             | 0xb0cf0e03
-node_guid_l             | 0x00cc0480
+node_guid_l             | 0x00ab1234
 capability_mask2        | 0x0000043b
 max_pkey                | 0x00000008
 node_description[0]     | 0x69737772
@@ -261,8 +261,8 @@ psu0[1]     | 0x00000002
 psu0[2]     | 0x80000124
 psu0[3]     | 0x00000001
 psu0[4]     | 0x4d543234
-psu0[5]     | 0x34315430
-psu0[6]     | 0x30314630
+psu0[5]     | 0x30315430
+psu0[6]     | 0x30305031
 psu0[7]     | 0x00000000
 psu0[8]     | 0x00000000
 psu0[9]     | 0x00000000
@@ -281,8 +281,8 @@ psu1[1]     | 0x00000002
 psu1[2]     | 0x8000012c
 psu1[3]     | 0x00000001
 psu1[4]     | 0x4d543234
-psu1[5]     | 0x34315430
-psu1[6]     | 0x30314554
+psu1[5]     | 0x30315430
+psu1[6]     | 0x30305032
 psu1[7]     | 0x00000000
 psu1[8]     | 0x00000000
 psu1[9]     | 0x00000000

--- a/tests/dumps/ibsw_dump_LID42_FW-LIMITED.txt
+++ b/tests/dumps/ibsw_dump_LID42_FW-LIMITED.txt
@@ -26,7 +26,7 @@ hw_dev_id                       | 0x0000024d
 manufacturing_base_mac_47_32    | 0x0000a088
 ga                              | 0x00000000
 chip_type                       | 0x00000000
-manufacturing_base_mac_31_0     | 0xc25f3d76
+manufacturing_base_mac_31_0     | 0xab12cd34
 uptime                          | 0x006c3edc
 sub_minor                       | 0x00000000
 minor                           | 0x00000000
@@ -145,9 +145,9 @@ Sending access register...
 
 Field Name          | Data    
 =================================
-serial_number[0]    | 0x4d543233
-serial_number[1]    | 0x33355430
-serial_number[2]    | 0x30423233
+serial_number[0]    | 0x4d543234
+serial_number[1]    | 0x30305430
+serial_number[2]    | 0x30414243
 serial_number[3]    | 0x00000000
 serial_number[4]    | 0x00000000
 serial_number[5]    | 0x00000000
@@ -199,9 +199,9 @@ psu0[0]     | 0x50000010
 psu0[1]     | 0x00000002
 psu0[2]     | 0x800000bb
 psu0[3]     | 0x00000001
-psu0[4]     | 0x4d543233
-psu0[5]     | 0x33355430
-psu0[6]     | 0x30335436
+psu0[4]     | 0x4d543234
+psu0[5]     | 0x30305430
+psu0[6]     | 0x30305031
 psu0[7]     | 0x00000000
 psu0[8]     | 0x00000000
 psu0[9]     | 0x00000000
@@ -219,9 +219,9 @@ psu1[0]     | 0x50000010
 psu1[1]     | 0x00000002
 psu1[2]     | 0x800000a4
 psu1[3]     | 0x00000001
-psu1[4]     | 0x4d543233
-psu1[5]     | 0x33355430
-psu1[6]     | 0x30335437
+psu1[4]     | 0x4d543234
+psu1[5]     | 0x30305430
+psu1[6]     | 0x30305032
 psu1[7]     | 0x00000000
 psu1[8]     | 0x00000000
 psu1[9]     | 0x00000000

--- a/tests/dumps/ibsw_dump_LID6_Sequana3-IB400.txt
+++ b/tests/dumps/ibsw_dump_LID6_Sequana3-IB400.txt
@@ -33,7 +33,7 @@ development                     | 0x00000000
 manufacturing_base_mac_47_32    | 0x00000800
 ga                              | 0x00000000
 chip_type                       | 0x00000000
-manufacturing_base_mac_31_0     | 0x38c5bf00
+manufacturing_base_mac_31_0     | 0x38ab1200
 device_ticks_per_msec           | 0x00000000
 uptime                          | 0x0007a567
 sub_minor                       | 0x00000000
@@ -159,8 +159,8 @@ Sending access register...
 
 Field Name          | Data
 =================================
-serial_number[0]    | 0x4a303235
-serial_number[1]    | 0x31363031
+serial_number[0]    | 0x4a393939
+serial_number[1]    | 0x39393939
 serial_number[2]    | 0x4a000000
 serial_number[3]    | 0x00000000
 serial_number[4]    | 0x00000000
@@ -224,11 +224,11 @@ router_entity           | 0x00000000
 swid                    | 0x00000000
 capability_mask         | 0xe550d848
 system_image_guid_h     | 0x08003803
-system_image_guid_l     | 0x00c5bf00
+system_image_guid_l     | 0x0012ab12
 guid0_h                 | 0x08003803
-guid0_l                 | 0x00c5bf00
+guid0_l                 | 0x0012ab12
 node_guid_h             | 0x08003803
-node_guid_l             | 0x00c5bf00
+node_guid_l             | 0x0012ab12
 capability_mask2        | 0x0000043b
 max_pkey                | 0x00000008
 node_description[0]     | 0x69737772

--- a/tests/dumps/ibsw_dump_LID77_JSON-SPECIAL.txt
+++ b/tests/dumps/ibsw_dump_LID77_JSON-SPECIAL.txt
@@ -35,7 +35,7 @@ development                     | 0x00000000
 manufacturing_base_mac_47_32    | 0x00000800
 ga                              | 0x00000000
 chip_type                       | 0x00000000
-manufacturing_base_mac_31_0     | 0x38c5bf00
+manufacturing_base_mac_31_0     | 0x38ab1200
 device_ticks_per_msec           | 0x00000000
 uptime                          | 0x0007a567
 sub_minor                       | 0x00000000
@@ -161,8 +161,8 @@ Sending access register...
 
 Field Name          | Data
 =================================
-serial_number[0]    | 0x4a303235
-serial_number[1]    | 0x31363031
+serial_number[0]    | 0x4a393939
+serial_number[1]    | 0x39393939
 serial_number[2]    | 0x4a000000
 serial_number[3]    | 0x00000000
 serial_number[4]    | 0x00000000
@@ -226,11 +226,11 @@ router_entity           | 0x00000000
 swid                    | 0x00000000
 capability_mask         | 0xe550d848
 system_image_guid_h     | 0x08003803
-system_image_guid_l     | 0x00c5bf00
+system_image_guid_l     | 0x0012ab12
 guid0_h                 | 0x08003803
-guid0_l                 | 0x00c5bf00
+guid0_l                 | 0x0012ab12
 node_guid_h             | 0x08003803
-node_guid_l             | 0x00c5bf00
+node_guid_l             | 0x0012ab12
 capability_mask2        | 0x0000043b
 max_pkey                | 0x00000008
 node_description[0]     | 0x22615c62

--- a/tests/dumps/ibsw_dump_LID99_MQM8790.txt
+++ b/tests/dumps/ibsw_dump_LID99_MQM8790.txt
@@ -145,9 +145,9 @@ Sending access register...
 
 Field Name          | Data    
 =================================
-serial_number[0]    | 0x4d543233
-serial_number[1]    | 0x33365430
-serial_number[2]    | 0x30414450
+serial_number[0]    | 0x4d543234
+serial_number[1]    | 0x30325430
+serial_number[2]    | 0x30474849
 serial_number[3]    | 0x00000000
 serial_number[4]    | 0x00000000
 serial_number[5]    | 0x00000000
@@ -205,9 +205,9 @@ psu0[0]     | 0x51000010
 psu0[1]     | 0x00000002
 psu0[2]     | 0x800000ec
 psu0[3]     | 0x00000001
-psu0[4]     | 0x4d543233
-psu0[5]     | 0x33365430
-psu0[6]     | 0x30344d46
+psu0[4]     | 0x4d543234
+psu0[5]     | 0x30325430
+psu0[6]     | 0x30305031
 psu0[7]     | 0x00000000
 psu0[8]     | 0x00000000
 psu0[9]     | 0x00000000
@@ -225,9 +225,9 @@ psu1[0]     | 0x51000010
 psu1[1]     | 0x00000002
 psu1[2]     | 0x80000029
 psu1[3]     | 0x00000001
-psu1[4]     | 0x4d543233
-psu1[5]     | 0x33365430
-psu1[6]     | 0x30344d47
+psu1[4]     | 0x4d543234
+psu1[5]     | 0x30325430
+psu1[6]     | 0x30305032
 psu1[7]     | 0x00000000
 psu1[8]     | 0x00000000
 psu1[9]     | 0x00000000


### PR DESCRIPTION
## Summary

Security/privacy hygiene. The seven dump files in \`tests/dumps/\` were captured from real switches and contained identifying hardware values (serial numbers, MAC addresses, GUIDs) that ended up published in this public fork. This PR replaces them with random-looking but format-preserving fakes so the fixtures remain useful for regression testing without leaking inventory data.

## What gets redacted

| Field | Where |
|-------|-------|
| Switch serial number | \`MSGI.serial_number[0..5]\` |
| Switch MAC | \`MGIR.manufacturing_base_mac_47_32 / _31_0\` |
| Switch GUID | \`SPZR.system_image_guid_h/l, guid0_h/l, node_guid_h/l\` |
| PSU serial numbers | \`MSPS.psu0[4..6], psu1[4..6]\` |

## What we keep on purpose

- Part numbers / model codes (\`MQM8790-HS2F\`, \`MQM9790-NS2F\`, \`11891122\`)
- PSID values (\`MT_*\`, \`BL_*\`) — vendor information, not user-identifying
- Product names (\`Sequana3 Unmng IB 400\`, \`Jaguar Unmng IB 200\`, ...)
- Node descriptions (\`iswr*\`) — already opaque enough per the requester
- Vendor OUI prefixes in MACs/GUIDs (\`08:00:38\`, \`b0:cf:0e\`, \`a0:88\`) — public information, identifies the silicon vendor only

## Mapping (consistency across derived fixtures)

| Source SN | Fake SN | Files |
|-----------|---------|-------|
| \`MT2335T00B23\` | \`MT2400T00ABC\` | 4.26.1, LID42 |
| \`MT2441T004F6\` | \`MT2401T00DEF\` | 4.33.0, LID0 |
| \`J0251601J\` | \`J9999999J\` | LID6, LID77 |
| \`MT2336T00ADP\` | \`MT2402T00GHI\` | LID99 |

Same logic for MACs and GUIDs (OUI preserved, lower bytes randomized). Files derived from the same source switch share the same fake, so internal consistency holds.

## Test plan

- [x] All 7 dumps pass \`./tests/run_tests.sh\` after redaction (the script is hardware-data agnostic — it parses by field name, not by value)
- [x] \`grep\` confirms no source value remains anywhere in \`tests/dumps/\`:
  ```
  for sn in MT2335T00B23 MT2441T004F6 J0251601J MT2336T00ADP; do
      grep -l "\$sn" tests/dumps/*.txt | wc -l
  done
  # all return 0
  ```

## Note on the README example

\`README.md\` currently shows a sample dashboard with \`switch-hdr-01\` etc. — those are already example values, not real data. No change needed there.